### PR TITLE
割り算の計算結果が無限小数でも表示可

### DIFF
--- a/lib/view/calculator_view.dart
+++ b/lib/view/calculator_view.dart
@@ -3,11 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:untitled/view_model/calculator_state_notifier.dart';
 
 class CalculatorView extends ConsumerWidget {
-  /*final String display = '0';*/
-
   const CalculatorView({super.key, required String display});
-
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(calculatorViewModelProvider);


### PR DESCRIPTION

<!--
このテンプレートを使用して Pull Request を作成する際は、以下のガイドラインに従ってください。
-->

## 概要
割り算の計算結果が無限小数でも表示可

## 関連する Issue
#2 

## 変更の詳細
①商が無限小数でも計算結果を表示
   修正前：2 ÷ 3 = →エラー
   修正後：2 ÷ 3 = 0.667 (小数第4位で四捨五入させています。）

②整数と小数点以下有りの場合の表示の修正
   修正前↓↓
      ex..8 ÷ 4 = 2.000
      ex.3 ÷ 2 = 1.500
   修正後↓↓
      ex.8 ÷ 4 = 2
      ex 3 ÷ 2 = 1.5

## テスト計画


## スクリーンショット（オプション）


## その他の情報（オプション）


## レビュワー

